### PR TITLE
Connect dashboard to backend

### DIFF
--- a/bugtracker-ui/src/components/Dashboard/Dashboard.css
+++ b/bugtracker-ui/src/components/Dashboard/Dashboard.css
@@ -132,10 +132,18 @@
     justify-content: space-between;
 }
 
+.dashboard .chart-container {
+    width: 30%;
+    height: 35vh;
+    position: relative
+}
+
 .dashboard .statistics-row { /* TODO: Add responsiveness to page sizes, If page is small it should be column not row*/
     display: flex;
     flex-direction: row;
     justify-content: space-around;
+    width: 100%;
+    margin-bottom: 20px;
 }
 
 .donut-chart {
@@ -147,10 +155,10 @@
                 user-select: none; /* Non-prefixed version, currently
                                     supported by Chrome and Opera */
 
-        display: flex;
+        /*display: flex;
           width: 25%;
           max-height: 400px;
-          max-width: 600px;
+          max-width: 600px; */
 }
 
 .dashboard .page-search {

--- a/bugtracker-ui/src/components/Dashboard/Dashboard.jsx
+++ b/bugtracker-ui/src/components/Dashboard/Dashboard.jsx
@@ -8,14 +8,19 @@ import { DashboardProjectsTable } from "../Tables/dashboardProjectsTable";
 import { DashboardTeamsTable } from "../Tables/DashboardTeamsTable";
 import DashboardProjectsModal from "./DashboardProjectsModal/DashboardProjectsModal";
 import DashboardTeamsModal from "./DashboardTeamsModal/DashboardTeamsModal";
+import { useProjectContext } from "../../contexts/project";
+import apiClient from "../../services/apiClient";
 
 export default function Dashboard() {
-  const { isOpen } = useOpenContext(); // Note: Open context is currently lagging dashboard. Fix later
+  const { isOpen } = useOpenContext() // Note: Open context is currently lagging dashboard. Fix later
+  const { projects, setProjects } = useProjectContext()
   const [dashboardProjectsModal, setDashboardProjectsModal] = useState(false)
   const [dashboardTeamsModal, setDashboardTeamsModal] = useState(false)
 
   useEffect(() => {
      renderCharts()
+     setProjects(apiClient.getAllProjects())
+     console.log(projects)
   }, [])
 
   return (
@@ -31,26 +36,41 @@ export default function Dashboard() {
         <div className="ticket-statistics">
           <h>TICKET STATISTICS</h>
           <div className="statistics-row">
-            <canvas // Renders a donut chart for category statistics
-              className="donut-chart"
-              id="category-chart"
-              width="800"
-              height="450"
-            ></canvas>
+            <div className="chart-container">
+              <canvas // Renders a donut chart for category statistics
+                className="donut-chart"
+                id="category-chart"
+                //width="20%"
+                //height="auto"
+                //maintainAspectRatio={false}
+                //width="800"
+                //height="450"
+              ></canvas>
+            </div>
             <br />
-            <canvas // Renders a donut chart for status statistics
-              className="donut-chart"
-              id="status-chart"
-              width="800"
-              height="450"
-            ></canvas>
+            <div className="chart-container">
+              <canvas // Renders a donut chart for status statistics
+                className="donut-chart"
+                id="status-chart"
+                //maintainAspectRatio={false}
+                //width="20%"
+                //height="auto"
+                //width="800"
+                //height="450"
+              ></canvas>
+            </div>
             <br />
-            <canvas // Renders a donut chart for priority statistics
-              className="donut-chart"
-              id="priority-chart"
-              width="800"
-              height="450"
-            ></canvas>
+            <div className="chart-container">
+              <canvas // Renders a donut chart for priority statistics
+                className="donut-chart"
+                id="priority-chart"
+                //maintainAspectRatio={false}
+                //width="20%"
+                //height="auto"
+                //width="800"
+                //height="450"
+              ></canvas>
+            </div>
           </div>
         </div>
 

--- a/bugtracker-ui/src/components/Dashboard/Dashboard.jsx
+++ b/bugtracker-ui/src/components/Dashboard/Dashboard.jsx
@@ -10,17 +10,24 @@ import DashboardProjectsModal from "./DashboardProjectsModal/DashboardProjectsMo
 import DashboardTeamsModal from "./DashboardTeamsModal/DashboardTeamsModal";
 import { useProjectContext } from "../../contexts/project";
 import apiClient from "../../services/apiClient";
+import { useTeamContext } from "../../contexts/team";
 
 export default function Dashboard() {
   const { isOpen } = useOpenContext() // Note: Open context is currently lagging dashboard. Fix later
   const { projects, setProjects } = useProjectContext()
+  const {teams, setTeams } = useTeamContext()
   const [dashboardProjectsModal, setDashboardProjectsModal] = useState(false)
   const [dashboardTeamsModal, setDashboardTeamsModal] = useState(false)
 
   useEffect(() => {
      renderCharts()
      setProjects(apiClient.getAllProjects())
+     setTeams(apiClient.listAllTeams())
+     /*console.log("Projects below")
      console.log(projects)
+     console.log("Teams below")
+     console.log(teams) */
+
   }, [])
 
   return (

--- a/bugtracker-ui/src/services/charts.js
+++ b/bugtracker-ui/src/services/charts.js
@@ -26,7 +26,8 @@ export default function renderCharts() {
       title: {
         display: true,
         text: 'Priority chart'
-      }
+      },
+      maintainAspectRatio: false
     }
     })
 
@@ -46,7 +47,8 @@ export default function renderCharts() {
           title: {
             display: true,
             text: 'Category chart'
-          }
+          },
+          maintainAspectRatio: false
         }
         })
 
@@ -66,7 +68,8 @@ export default function renderCharts() {
             title: {
             display: true,
             text: 'Status chart'
-            }
+            },
+            maintainAspectRatio: false
         }
         })
         /*


### PR DESCRIPTION
The dashboard can now retrieve projects and teams from the backend. I'm merging into main now to access the updated modals on the teams/projects pages to implement them into the dashboard so users can directly create teams/projects from there