### PR TITLE
Fixed bug where a client has to send in user ids to update the member…

### DIFF
--- a/bugtracker-api/models/ticket.js
+++ b/bugtracker-api/models/ticket.js
@@ -240,6 +240,16 @@ class Tickets
             throw new BadRequestError(`New Ticket Information is missing!`)
         }
 
+        let developers = []
+        if(ticketInfo.hasOwnProperty("developers"))
+        {
+            ticketInfo["developers"]?.forEach(async(developer) => {
+                const devId = await Teams.fetchUserId(developer)
+                developers.push(devId)
+            })
+            ticketInfo["developers"] = developers
+        }
+
 
         //Run a query to retrieve the id of the user using the email from the local server
         const userId = await Teams.fetchUserId(user.email)


### PR DESCRIPTION
Backend: 

- Reworked an issue where client has to send in user ids to update the developers field within the ticket tables
- Client just has to send in user emails and backend will do the work to find the user ids (this decreases the amount of calls made to the api server)