### PR TITLE
Create ticket projects page

### DIFF
--- a/bugtracker-api/models/ticket.js
+++ b/bugtracker-api/models/ticket.js
@@ -47,6 +47,7 @@ class Tickets
 
         //Run a separate query to check if the user is able to access project information
         //If undefined, then throw a not found error because user is neither a creator or member of the project
+
         const validAccess = await Tickets.validUserAccess(projectId, userId)
         if(!validAccess)
         {
@@ -93,10 +94,9 @@ class Tickets
         const results = await db.query(
             `
                 SELECT *
-                FROM projects
-                    LEFT JOIN teams ON teams.id = projects.id
-                WHERE projects.id = $1 AND ((projects.creator_id = $2) 
-                OR ($2 = any(teams.members)))
+                FROM projects as pro
+                    LEFT JOIN teams ON teams.id = any(pro.teams)
+                WHERE pro.id = $1 AND ((pro.creator_id = $1) OR  $2 = any(SELECT UNNEST(members) FROM teams WHERE id = any(pro.teams)))
             `, [projectId, userId])
         
         //If user is a creator or member of a project, then return project information; Else, return undefined

--- a/bugtracker-api/routes/ticket.js
+++ b/bugtracker-api/routes/ticket.js
@@ -24,14 +24,17 @@ router.get("/", security.requireAuthenticatedUser, async(req,res,next) => {
 })
 
 //FUNCTION TO LIST ALL THE TICKETS FOR A SELECTED PROJECT 
-router.get("/:projectId", security.requireAuthenticatedUser, async(req,res,next) => {
+router.get("/project/:projectId", security.requireAuthenticatedUser, async(req,res,next) => {
     try
     {
         //Retrieve the user information from the local server
         const {user} = res.locals
+
+        const {projectId} = req.params
+
         //Call the listAllTickets function to get a list of all the tickets from a specific project
         //Request body should have the projectId
-        const ticketList = await Tickets.listAllProjectTickets({user: user, projectId: req.params.projectId})
+        const ticketList = await Tickets.listAllProjectTickets({user: user, projectId: parseInt(projectId)})
         //Return the list of all the tickets if successful
         return res.status(200).json({ticketList: ticketList})
     }

--- a/bugtracker-ui/src/components/App/App.jsx
+++ b/bugtracker-ui/src/components/App/App.jsx
@@ -74,7 +74,6 @@ export function App() {
       if (data) {
         setUser(data.user);
         fetchTeams();
-        console.log("App.jsx teams:", teams)
         fetchDashboardStatistics()
       }
       setInitialized(true);

--- a/bugtracker-ui/src/components/Dropdown/AddDevelopersDropdown/AddDevelopersDropdown.jsx
+++ b/bugtracker-ui/src/components/Dropdown/AddDevelopersDropdown/AddDevelopersDropdown.jsx
@@ -1,9 +1,10 @@
 import "./AddDevelopersDropdown.css";
 
 export default function AddDevelopersDropdown({ developers, onClick }) {
+  
   return (
     <div className="dropdown-container">
-      {developers.map((d) => (
+      {developers?.map((d) => (
         <div className="option-row" onClick={() => onClick(d)}>
           <p>{d}</p>
         </div>

--- a/bugtracker-ui/src/components/Dropdown/AddDevelopersDropdown/AddDevelopersDropdown.jsx
+++ b/bugtracker-ui/src/components/Dropdown/AddDevelopersDropdown/AddDevelopersDropdown.jsx
@@ -1,6 +1,6 @@
 import "./AddDevelopersDropdown.css";
 
-export default function AddDevelopersDropdown({ developers, onClick }) {
+export default function AddDevelopersDropdown({ developers, onClick,}) {
   
   return (
     <div className="dropdown-container">

--- a/bugtracker-ui/src/components/Modals/TicketModal/TicketModal.jsx
+++ b/bugtracker-ui/src/components/Modals/TicketModal/TicketModal.jsx
@@ -98,6 +98,8 @@ export default function TicketModal({
     }
   }, []);
 
+  
+
   return (
     <div className="ticket-modal-background">
       <div className="ticket-modal-container">
@@ -272,7 +274,7 @@ export function AddDevelopers({ developers, setDevelopersToAdd }) {
   // useEffect hook to update developersToShow whenever developerSearch changes
   useEffect(() => {
     setDevelopersToShow(
-      developers.filter((d) =>
+      developers?.filter((d) =>
         d.toLowerCase().includes(developerSearch.toLowerCase())
       )
     );

--- a/bugtracker-ui/src/components/Tables/ProjectsPageTicketsTable.jsx
+++ b/bugtracker-ui/src/components/Tables/ProjectsPageTicketsTable.jsx
@@ -15,7 +15,7 @@ const columns = [
 
 export const ProjectsPageTicketsTable = ({ currentProject }) => {
   const [tickets, setTickets] = useState([]);
-  const { setCurrentTicket } = useTicketContext();
+  const { setCurrentTicket, currentTicket } = useTicketContext();
   const {ticketModal, setTicketModal} = useTicketContext()
 
   const navigate = useNavigate();
@@ -42,7 +42,7 @@ export const ProjectsPageTicketsTable = ({ currentProject }) => {
 
   useEffect(() => {
     fetchTickets();
-  }, [currentProject]);
+  }, [currentProject, currentTicket]);
 
   return (
     tickets && (

--- a/bugtracker-ui/src/hooks/useTicketForm.js
+++ b/bugtracker-ui/src/hooks/useTicketForm.js
@@ -31,6 +31,15 @@ export const useTicketForm = () => {
           // send request to create new a ticket
             // must send: 
             // title, description, category, priority, status, complexity, the developers (array of emails), projectId
+              console.log("Submitting: ", {title: title,
+              description: description,
+              category: category,
+              priority: priority,
+              status: status,
+              complexity:complexity,
+              developers: developersToAdd,
+              projectId: selectedProject,})
+
             const { data, error } = await apiClient.createNewTicket({
               title: title,
               description: description,

--- a/bugtracker-ui/src/hooks/useTicketForm.js
+++ b/bugtracker-ui/src/hooks/useTicketForm.js
@@ -31,14 +31,6 @@ export const useTicketForm = () => {
           // send request to create new a ticket
             // must send: 
             // title, description, category, priority, status, complexity, the developers (array of emails), projectId
-              console.log("Submitting: ", {title: title,
-              description: description,
-              category: category,
-              priority: priority,
-              status: status,
-              complexity:complexity,
-              developers: developersToAdd,
-              projectId: selectedProject,})
 
             const { data, error } = await apiClient.createNewTicket({
               title: title,

--- a/bugtracker-ui/src/services/apiClient.js
+++ b/bugtracker-ui/src/services/apiClient.js
@@ -104,14 +104,14 @@ class ApiClient {
     }
   // list all the tickets for  selected project  
   async listAllProjectTickets(projectId){
-    return await this.request({ endpoint: `ticket/${projectId}`, method: 'GET' })
+    return await this.request({ endpoint: `ticket/project/${projectId}`, method: 'GET' })
   }
   // to create a new tickets credentials must have: 
   // the developers (array of emails), projectId, title, description, category, priority, status, complexity
   async createNewTicket(credentials){
     return await this.request({ endpoint: 'ticket', method: 'POST', data: credentials })
   }
-  async fetchTicketById(ticketId){
+  async fetchTicketById(ticketId){s
     return await this.request({ endpoint: `ticket/${ticketId}`, method: 'GET'})
   }
   async updateTicket(ticketId, ticketInfo){


### PR DESCRIPTION
Backend:

- Fixed a bug on the backend where project id was being passed to the listAllTicketsForProjects function in the form of a string rather than an integer
- Fixed permissions on validUserAccess in Tickets Model where user was not able to access a project even though they were a creator or member

Frontend:

- Added a create ticket functionality to the projects page where a user can now create tickets from this page as well as the ticket's page